### PR TITLE
Add survivor and run manager scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Godot
+.import/
+.godot/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# jeuxleo1
+# Survivants Prototype
+
+Minimal Godot 4 project sketch for the "Survivants" roguelite deckbuilder.
+
+## Contents
+- `scenes/Main.tscn` – starting scene
+- `scripts/Main.gd` – loads the project and unlocks the first building
+- `scripts/Card.gd`, `scripts/Building.gd`, `scripts/Survivor.gd`, `scripts/RunManager.gd` – placeholder resources for core systems
+
+## Running
+Open the folder with Godot 4 or run `godot4 --path .` if the engine is installed.

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,8 @@
+[gd_resource type="ConfigFile" format=3]
+
+[application]
+config/name="Survivants"
+run/main_scene="res://scenes/Main.tscn"
+
+[rendering]
+quality/intended_usage/framebuffer_allocation=2

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Main.gd" id="1"]
+
+[node name="Main" type="Node"]
+script = ExtResource(1)

--- a/scripts/Building.gd
+++ b/scripts/Building.gd
@@ -1,0 +1,6 @@
+extends Resource
+class_name Building
+
+@export var name: String
+@export var level: int = 1
+@export var production_rate: float = 0.0

--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -1,0 +1,6 @@
+extends Resource
+class_name Card
+
+@export var name: String
+@export var description: String
+@export var cost: int

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -1,0 +1,9 @@
+extends Node
+
+var run_manager: RunManager
+
+func _ready():
+    print("Survivants project loaded.")
+    run_manager = RunManager.new()
+    add_child(run_manager)
+    run_manager.unlock_next_building()

--- a/scripts/RunManager.gd
+++ b/scripts/RunManager.gd
@@ -1,0 +1,14 @@
+extends Node
+class_name RunManager
+
+var building_order := ["Farm", "Factory", "Refuge", "Armory"]
+var unlocked_buildings: Array[String] = []
+
+var food: int = 0
+var materials: int = 0
+
+func unlock_next_building() -> void:
+    if building_order.size() > unlocked_buildings.size():
+        var next = building_order[unlocked_buildings.size()]
+        unlocked_buildings.append(next)
+        print("Unlocked %s" % next)

--- a/scripts/Survivor.gd
+++ b/scripts/Survivor.gd
@@ -1,0 +1,19 @@
+extends Resource
+class_name Survivor
+
+@export var name: String
+@export var level: int = 1
+@export var deck: Array[Card] = []
+@export var experience: int = 0
+
+func add_card(card: Card) -> void:
+    deck.append(card)
+
+func remove_card(card: Card) -> void:
+    deck.erase(card)
+
+func gain_experience(points: int) -> void:
+    experience += points
+    if experience >= level * 100:
+        experience = 0
+        level += 1


### PR DESCRIPTION
## Summary
- Add Survivor resource with basic leveling and deck management
- Introduce RunManager node to unlock buildings sequentially
- Expand main script and README for project overview

## Testing
- `godot4 --version` *(command not found)*
- `apt-get install -y godot4` *(unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b4432edf6c832fa7407833df560e4f