### PR TITLE
Add start scripts and sample content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Godot
+.import/
+.godot/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# jeuxleo1
+# Survivants Prototype
+
+Minimal Godot 4 project sketch for the "Survivants" roguelite deckbuilder.
+
+## Contents
+- `scenes/Main.tscn` – starting scene
+- `scripts/Main.gd` – loads the project and unlocks the first building
+- `scripts/Card.gd`, `scripts/Building.gd`, `scripts/Survivor.gd`, `scripts/RunManager.gd` – placeholder resources for core systems
+
+## Running
+To launch the project directly:
+
+- On Linux/macOS run `./start.sh`
+- On Windows run `start.bat`
+
+Both scripts expect `godot4` to be available in your `PATH`. You can also open the folder in the Godot editor or run `godot4 --path .` manually.
+
+The `resources/` folder contains early examples of cards, buildings, and a survivor to begin expanding the game's content.

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,8 @@
+[gd_resource type="ConfigFile" format=3]
+
+[application]
+config/name="Survivants"
+run/main_scene="res://scenes/Main.tscn"
+
+[rendering]
+quality/intended_usage/framebuffer_allocation=2

--- a/resources/buildings/Factory.tres
+++ b/resources/buildings/Factory.tres
@@ -1,0 +1,6 @@
+[gd_resource type="Building" format=3]
+
+[resource]
+name="Usine"
+level=1
+production_rate=1.0

--- a/resources/buildings/Farm.tres
+++ b/resources/buildings/Farm.tres
@@ -1,0 +1,6 @@
+[gd_resource type="Building" format=3]
+
+[resource]
+name="Ferme"
+level=1
+production_rate=2.5

--- a/resources/cards/Block.tres
+++ b/resources/cards/Block.tres
@@ -1,0 +1,6 @@
+[gd_resource type="Card" format=3]
+
+[resource]
+name="Blocage"
+description="Gagne 5 armure."
+cost=1

--- a/resources/cards/Punch.tres
+++ b/resources/cards/Punch.tres
@@ -1,0 +1,6 @@
+[gd_resource type="Card" format=3]
+
+[resource]
+name="Coup de Poing"
+description="Inflige 5 dégâts."
+cost=1

--- a/resources/survivors/Nomade.tres
+++ b/resources/survivors/Nomade.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Survivor" load_steps=3 format=3]
+[ext_resource type="Card" path="res://resources/cards/Punch.tres" id="1"]
+[ext_resource type="Card" path="res://resources/cards/Block.tres" id="2"]
+
+[resource]
+name="Nomade"
+deck=[ExtResource(1), ExtResource(2)]
+level=1
+experience=0

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Main.gd" id="1"]
+
+[node name="Main" type="Node"]
+script = ExtResource(1)

--- a/scripts/Building.gd
+++ b/scripts/Building.gd
@@ -1,0 +1,6 @@
+extends Resource
+class_name Building
+
+@export var name: String
+@export var level: int = 1
+@export var production_rate: float = 0.0

--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -1,0 +1,6 @@
+extends Resource
+class_name Card
+
+@export var name: String
+@export var description: String
+@export var cost: int

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -1,0 +1,12 @@
+extends Node
+
+var run_manager: RunManager
+
+func _ready():
+    print("Survivants project loaded.")
+    run_manager = RunManager.new()
+    add_child(run_manager)
+    run_manager.unlock_next_building()
+
+    var survivor: Survivor = load("res://resources/survivors/Nomade.tres")
+    print("Loaded survivor %s with %d cards" % [survivor.name, survivor.deck.size()])

--- a/scripts/RunManager.gd
+++ b/scripts/RunManager.gd
@@ -1,0 +1,22 @@
+extends Node
+class_name RunManager
+
+var building_order: Array = [
+    preload("res://resources/buildings/Farm.tres"),
+    preload("res://resources/buildings/Factory.tres"),
+    "Refuge",
+    "Armory"
+]
+var unlocked_buildings: Array = []
+
+var food: int = 0
+var materials: int = 0
+
+func unlock_next_building() -> void:
+    if building_order.size() > unlocked_buildings.size():
+        var next = building_order[unlocked_buildings.size()]
+        unlocked_buildings.append(next)
+        if next is Building:
+            print("Unlocked %s" % next.name)
+        else:
+            print("Unlocked %s" % next)

--- a/scripts/Survivor.gd
+++ b/scripts/Survivor.gd
@@ -1,0 +1,19 @@
+extends Resource
+class_name Survivor
+
+@export var name: String
+@export var level: int = 1
+@export var deck: Array[Card] = []
+@export var experience: int = 0
+
+func add_card(card: Card) -> void:
+    deck.append(card)
+
+func remove_card(card: Card) -> void:
+    deck.erase(card)
+
+func gain_experience(points: int) -> void:
+    experience += points
+    if experience >= level * 100:
+        experience = 0
+        level += 1

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,5 @@
+@echo off
+REM Launch the Survivants project with Godot 4.
+REM Requires godot4 to be available in PATH.
+
+godot4 --path %~dp0 %*

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Launch the Survivants project with Godot 4.
+# Requires `godot4` to be available in PATH.
+
+godot4 --path "$(dirname "$0")" "$@"


### PR DESCRIPTION
## Summary
- Provide cross-platform start scripts to launch the project
- Add initial card, building, and survivor resources
- Load sample survivor and building data at runtime

## Testing
- `godot4 --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4432edf6c832fa7407833df560e4f